### PR TITLE
Fix walking sound continuing after shooting an arrow

### DIFF
--- a/src/scenes/scene-base.ts
+++ b/src/scenes/scene-base.ts
@@ -217,6 +217,7 @@ export class SceneBase extends Phaser.Scene {
 			this.isUsingBow = false;
 			me.playAnimation('rest');
 			me.emit('shot-arrow', arrow);
+			audioManager.stop(AUDIO_FOOTSTEPS,100);
 		});
 		control.on('change', (angle, percent) => {
 			console.log('Control change');


### PR DESCRIPTION
Added a line to scene-base.ts to make sure walking sound stops after player fires an arrow.

Resolves: #1